### PR TITLE
raised ZYNQMP_DMA_NUM_DESCS from 32 to 10000 and replace spin_lock_bh with spin_lock_irqsave 

### DIFF
--- a/drivers/dma/xilinx/zynqmp_dma.c
+++ b/drivers/dma/xilinx/zynqmp_dma.c
@@ -122,7 +122,7 @@
 					ZYNQMP_DMA_DST_DSCR_DONE)
 
 /* Max number of descriptors per channel */
-#define ZYNQMP_DMA_NUM_DESCS	32
+#define ZYNQMP_DMA_NUM_DESCS	10000
 
 /* Max transfer size per descriptor */
 #define ZYNQMP_DMA_MAX_TRANS_LEN	0x40000000

--- a/drivers/dma/xilinx/zynqmp_dma.c
+++ b/drivers/dma/xilinx/zynqmp_dma.c
@@ -669,7 +669,6 @@ static void zynqmp_dma_free_descriptors(struct zynqmp_dma_chan *chan)
  */
 static void zynqmp_dma_free_chan_resources(struct dma_chan *dchan)
 {
-	unsigned long irqflags;
 	struct zynqmp_dma_chan *chan = to_chan(dchan);
 	unsigned long irqflags;
 


### PR DESCRIPTION
1. raise ZYNQMP_DMA_NUM_DESCS from 32 to 10000 to enhance the max dma transfers from ~64KB to ~20MB
Why 10000? Because it is enough for a dma copy of a 2448x2048 ARGB image with 4KB pages!

2. replace spin_lock_bh with spin_lock_irqsave:
All device_prep_dma_* functions and device_issue_pending can be called
from an interrupt context. As this includes hard IRQs, we must use
spin_lock_irqsave() instead of spin_lock_bh() to access chan->lock.
